### PR TITLE
[#27] 상품 정보 모달에서 변경사항이 없을 때 [저장] 버튼이 비활성화 되지 않는 문제 수정

### DIFF
--- a/frontend/src/modals/ModifyProduct.tsx
+++ b/frontend/src/modals/ModifyProduct.tsx
@@ -16,7 +16,7 @@ import {
   Tooltip,
   VStack,
 } from '@chakra-ui/react';
-import { isEqual, some } from 'lodash';
+import { some } from 'lodash';
 import { useCallback } from 'react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { useRecoilValue } from 'recoil';
@@ -57,10 +57,7 @@ export const ModifyProduct = ({ isOpen, onClose, productInfo }: Props) => {
   });
 
   const onSubmit: SubmitHandler<FormValues> = data => {
-    if (!isEqual(productInfo, data)) {
-      // 값이 초기값과 같지 않을때만 API 요청
-      // TODO: Issue-20 상품 수정 API 연동 예정
-    }
+    // TODO: Issue-20 상품 수정 API 연동 예정
     onClose();
   };
 
@@ -149,6 +146,7 @@ export const ModifyProduct = ({ isOpen, onClose, productInfo }: Props) => {
                 variant="filled"
                 {...register('defaultPrice', {
                   required: true,
+                  valueAsNumber: true,
                 })}
                 style={{
                   border: errors.defaultPrice ? '2px solid red' : '',


### PR DESCRIPTION
## Description
상품 정보 모달에서 기존값의 변경사항이 없는 경우 [저장] 버튼 비활성화가 되지 않는 문제 해결
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## What type of PR is this?
- [X] 🐛 Bug Fix

### 작업된 화면
![issue-27](https://github.com/user-attachments/assets/00e2dd2f-c0d0-4a32-82a1-7da23db8c28e)

## Issue
close #27 