### PR TITLE
[#20] 상품 정보 모달 [저장] 버튼에 상품 수정 API 연동

### DIFF
--- a/frontend/src/mockApi.tsx
+++ b/frontend/src/mockApi.tsx
@@ -1,4 +1,5 @@
-import axios from 'axios';
+import type { MutateFunction } from '@tanstack/react-query';
+import axios, { type AxiosResponse } from 'axios';
 import type { ProductWithoutSalesRecord, ProductWithSalesRecord } from 'src/types/dto';
 
 const mockBaseUrl = '/mocks';
@@ -11,3 +12,9 @@ export const getProductList = async () =>
 
 export const addNewProduct = (newProduct: Omit<ProductWithoutSalesRecord, 'id' | 'itemsReceivedCount'>) =>
   mockInstance.post('/post/add-new-product', newProduct);
+
+export const modProduct: MutateFunction<
+  AxiosResponse<ProductWithoutSalesRecord>,
+  Error,
+  { newProduct: Omit<ProductWithoutSalesRecord, 'itemsReceivedCount'> }
+> = ({ newProduct }) => mockInstance.post(`/post/mod-product/${newProduct.id}`, newProduct);

--- a/frontend/src/modals/ModifyProduct.tsx
+++ b/frontend/src/modals/ModifyProduct.tsx
@@ -14,13 +14,16 @@ import {
   Switch,
   Text,
   Tooltip,
+  useToast,
   VStack,
 } from '@chakra-ui/react';
+import { useMutation } from '@tanstack/react-query';
 import { some } from 'lodash';
 import { useCallback } from 'react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { useRecoilValue } from 'recoil';
 import type { Category, ProductWithSalesRecord } from 'src/types/dto';
+import { modProduct } from '../mockApi';
 import { CATEGORIES } from '../modals/consts';
 import { productNameListState } from '../store/product';
 
@@ -44,6 +47,21 @@ type Props = {
 
 export const ModifyProduct = ({ isOpen, onClose, productInfo }: Props) => {
   const productNameList = useRecoilValue(productNameListState);
+  const toast = useToast();
+
+  const { mutate: updateMutate } = useMutation({
+    mutationFn: modProduct,
+    onSuccess: result => {
+      toast({
+        title: '상품 수정에 성공했어요 ✏️',
+        status: 'success',
+        position: 'top',
+        duration: 1000,
+        isClosable: true,
+      });
+      onClose();
+    },
+  });
 
   const {
     formState: { errors, isValid, isSubmitting, isDirty },
@@ -57,7 +75,11 @@ export const ModifyProduct = ({ isOpen, onClose, productInfo }: Props) => {
   });
 
   const onSubmit: SubmitHandler<FormValues> = data => {
-    // TODO: Issue-20 상품 수정 API 연동 예정
+    const newProduct = {
+      ...data,
+      id: productInfo.id,
+    };
+    updateMutate({ newProduct });
     onClose();
   };
 


### PR DESCRIPTION
## Description
- 상품 정보 데이터에 변경사항이 있을 때, [저장] 버튼 클릭 시 상품 수정 API 호출
- 상품 수정 성공 시 성공 토스트 안내

## What type of PR is this?
- [X] 🍕 Feature

## Issue
close #20