### PR TITLE
[#21] 상품 삭제 버튼 추가 및 API 연동

### DIFF
--- a/frontend/src/components/Popover/Container.tsx
+++ b/frontend/src/components/Popover/Container.tsx
@@ -10,7 +10,7 @@ import {
 } from '@chakra-ui/react';
 import type { MutableRefObject, PropsWithChildren } from 'react';
 
-type TriggerProps = {
+type PopoverContainer = {
   name: string;
   bgColor?: string;
   fontColor?: string;
@@ -25,7 +25,7 @@ export const PopoverContainer = ({
   bgColor = 'yellow',
   fontColor = '#f8f8f8',
   children,
-}: TriggerProps) => {
+}: PopoverContainer) => {
   return (
     <Popover placement="top-start">
       <PopoverTrigger>

--- a/frontend/src/components/Popover/Container.tsx
+++ b/frontend/src/components/Popover/Container.tsx
@@ -1,0 +1,62 @@
+import {
+  Button,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverTrigger,
+  Portal,
+} from '@chakra-ui/react';
+import type { MutableRefObject, PropsWithChildren } from 'react';
+
+type TriggerProps = {
+  name: string;
+  bgColor?: string;
+  fontColor?: string;
+} & PropsWithChildren;
+
+type ContentProps = {
+  modalRef: MutableRefObject<HTMLElement | null>;
+} & PropsWithChildren;
+
+export const PopoverContainer = ({
+  name,
+  bgColor = 'yellow',
+  fontColor = '#f8f8f8',
+  children,
+}: TriggerProps) => {
+  return (
+    <Popover placement="top-start">
+      <PopoverTrigger>
+        <Button
+          _hover={{
+            textDecoration: 'none',
+            rounded: 'xl',
+            transform: 'scale(1.2)',
+          }}
+          color={fontColor}
+          colorScheme={bgColor}
+          rounded="xl"
+        >
+          {name}
+        </Button>
+      </PopoverTrigger>
+      {children}
+    </Popover>
+  );
+};
+
+export const Content = ({ modalRef, children }: ContentProps) => {
+  return (
+    <Portal containerRef={modalRef}>
+      <PopoverContent bg="gray.200" w="100%">
+        <PopoverArrow />
+        <PopoverCloseButton />
+        <PopoverBody>{children}</PopoverBody>
+      </PopoverContent>
+    </Portal>
+  );
+};
+
+PopoverContainer.Content = Content;

--- a/frontend/src/components/Popover/index.ts
+++ b/frontend/src/components/Popover/index.ts
@@ -1,0 +1,3 @@
+import { PopoverContainer } from './Container';
+
+export default PopoverContainer;

--- a/frontend/src/components/Popover/type.ts
+++ b/frontend/src/components/Popover/type.ts
@@ -1,0 +1,9 @@
+import type { MutableRefObject } from 'react';
+
+export type PopoverProps = {
+  name: string;
+  modalRef: MutableRefObject<HTMLElement | null>;
+  onDelete: VoidFunction;
+  bgColor?: string;
+  fontColor?: string;
+};

--- a/frontend/src/mockApi.tsx
+++ b/frontend/src/mockApi.tsx
@@ -18,3 +18,11 @@ export const modProduct: MutateFunction<
   Error,
   { newProduct: Omit<ProductWithoutSalesRecord, 'itemsReceivedCount'> }
 > = ({ newProduct }) => mockInstance.post(`/post/mod-product/${newProduct.id}`, newProduct);
+
+export const cancelProduct: MutateFunction<
+  {
+    message: string;
+  },
+  Error,
+  { id: number }
+> = ({ id }) => mockInstance.get(`/get/cancel-product/${id}`).then(response => response.data);

--- a/frontend/src/mockApi.tsx
+++ b/frontend/src/mockApi.tsx
@@ -19,7 +19,7 @@ export const modProduct: MutateFunction<
   { newProduct: Omit<ProductWithoutSalesRecord, 'itemsReceivedCount'> }
 > = ({ newProduct }) => mockInstance.post(`/post/mod-product/${newProduct.id}`, newProduct);
 
-export const cancelProduct: MutateFunction<
+export const deleteProduct: MutateFunction<
   {
     message: string;
   },

--- a/frontend/src/modals/ModifyProduct.tsx
+++ b/frontend/src/modals/ModifyProduct.tsx
@@ -31,7 +31,7 @@ import { useCallback, useRef, type MutableRefObject } from 'react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { useRecoilValue } from 'recoil';
 import type { Category, ProductWithSalesRecord } from 'src/types/dto';
-import { cancelProduct, modProduct } from '../mockApi';
+import { deleteProduct, modProduct } from '../mockApi';
 import { CATEGORIES } from '../modals/consts';
 import { productNameListState } from '../store/product';
 
@@ -72,7 +72,7 @@ export const ModifyProduct = ({ isOpen, onClose, productInfo }: Props) => {
   });
 
   const { mutate: deleteMutate } = useMutation({
-    mutationFn: cancelProduct,
+    mutationFn: deleteProduct,
     onSuccess: () => {
       toast({
         title: '상품 삭제에 성공했어요 ✏️',

--- a/frontend/src/modals/ModifyProduct.tsx
+++ b/frontend/src/modals/ModifyProduct.tsx
@@ -83,6 +83,16 @@ export const ModifyProduct = ({ isOpen, onClose, productInfo }: Props) => {
       });
       onClose();
     },
+    onError: () => {
+      toast({
+        title: '상품 삭제에 실패했어요 🥲',
+        status: 'error',
+        position: 'top',
+        duration: 1000,
+        isClosable: true,
+      });
+      onClose();
+    },
   });
 
   const {

--- a/frontend/src/modals/ModifyProduct.tsx
+++ b/frontend/src/modals/ModifyProduct.tsx
@@ -11,13 +11,6 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  Popover,
-  PopoverArrow,
-  PopoverBody,
-  PopoverCloseButton,
-  PopoverContent,
-  PopoverTrigger,
-  Portal,
   Select,
   Switch,
   Text,
@@ -27,10 +20,12 @@ import {
 } from '@chakra-ui/react';
 import { useMutation } from '@tanstack/react-query';
 import { some } from 'lodash';
-import { useCallback, useRef, type MutableRefObject } from 'react';
+import { useCallback, useRef } from 'react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { useRecoilValue } from 'recoil';
 import type { Category, ProductWithSalesRecord } from 'src/types/dto';
+import PopoverContainer from '../components/Popover';
+import type { PopoverProps } from '../components/Popover/type';
 import { deleteProduct, modProduct } from '../mockApi';
 import { CATEGORIES } from '../modals/consts';
 import { productNameListState } from '../store/product';
@@ -222,7 +217,7 @@ export const ModifyProduct = ({ isOpen, onClose, productInfo }: Props) => {
             </HStack>
           </VStack>
           <ModalFooter mx={0} px={0}>
-            <DeleteProductButton modalRef={ref} onDelete={handleDelete} />
+            <DeleteProductButton name="삭제" modalRef={ref} onDelete={handleDelete} />
             <Flex
               css={{ WebkitMarginStart: 0 }}
               justifyContent="flex-end"
@@ -271,43 +266,17 @@ export const ModifyProduct = ({ isOpen, onClose, productInfo }: Props) => {
   );
 };
 
-const DeleteProductButton = ({
-  modalRef,
-  onDelete,
-}: {
-  modalRef: MutableRefObject<HTMLElement | null>;
-  onDelete: VoidFunction;
-}) => {
+const DeleteProductButton = ({ name, modalRef, onDelete }: PopoverProps) => {
   return (
-    <Popover placement="top-start">
-      <PopoverTrigger>
-        <Button
-          _hover={{
-            textDecoration: 'none',
-            rounded: 'xl',
-            transform: 'scale(1.2)',
-          }}
-          color="#f8f8f8"
-          colorScheme="yellow"
-          rounded="xl"
-        >
-          삭제
+    <PopoverContainer name={name}>
+      <PopoverContainer.Content modalRef={modalRef}>
+        <Heading fontSize="2xl" my="3vh">
+          상품을 삭제할까요?
+        </Heading>
+        <Button colorScheme="yellow" onClick={onDelete}>
+          삭제할게요!
         </Button>
-      </PopoverTrigger>
-      <Portal containerRef={modalRef}>
-        <PopoverContent bg="gray.200" w="100%">
-          <PopoverArrow />
-          <PopoverCloseButton />
-          <PopoverBody>
-            <Heading fontSize="2xl" my="3vh">
-              상품을 삭제할까요?
-            </Heading>
-            <Button colorScheme="yellow" onClick={onDelete}>
-              삭제할게요!
-            </Button>
-          </PopoverBody>
-        </PopoverContent>
-      </Portal>
-    </Popover>
+      </PopoverContainer.Content>
+    </PopoverContainer>
   );
 };

--- a/frontend/src/modals/ModifyProduct.tsx
+++ b/frontend/src/modals/ModifyProduct.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Flex,
+  Heading,
   HStack,
   Input,
   Modal,
@@ -10,6 +11,13 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverTrigger,
+  Portal,
   Select,
   Switch,
   Text,
@@ -19,7 +27,7 @@ import {
 } from '@chakra-ui/react';
 import { useMutation } from '@tanstack/react-query';
 import { some } from 'lodash';
-import { useCallback } from 'react';
+import { useCallback, useRef, type MutableRefObject } from 'react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { useRecoilValue } from 'recoil';
 import type { Category, ProductWithSalesRecord } from 'src/types/dto';
@@ -27,7 +35,6 @@ import { modProduct } from '../mockApi';
 import { CATEGORIES } from '../modals/consts';
 import { productNameListState } from '../store/product';
 
-// JSON Array
 type FormValues = {
   category: Category;
   name: string;
@@ -48,6 +55,7 @@ type Props = {
 export const ModifyProduct = ({ isOpen, onClose, productInfo }: Props) => {
   const productNameList = useRecoilValue(productNameListState);
   const toast = useToast();
+  const ref = useRef<HTMLElement | null>(null);
 
   const { mutate: updateMutate } = useMutation({
     mutationFn: modProduct,
@@ -88,10 +96,14 @@ export const ModifyProduct = ({ isOpen, onClose, productInfo }: Props) => {
     return !some(productNameList, name => name === value);
   }, []);
 
+  const handleDelete = () => {
+    // TODO: 삭제 API 연동
+  };
+
   return (
     <Modal isCentered isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
-      <ModalContent m="3%">
+      <ModalContent m="3%" ref={ref}>
         <ModalHeader>상품 정보 ✏️</ModalHeader>
         <ModalCloseButton />
         <ModalBody as="form" onSubmit={handleSubmit(onSubmit)}>
@@ -188,6 +200,7 @@ export const ModifyProduct = ({ isOpen, onClose, productInfo }: Props) => {
             </HStack>
           </VStack>
           <ModalFooter mx={0} px={0}>
+            <DeleteProductButton modalRef={ref} onDelete={handleDelete} />
             <Flex
               css={{ WebkitMarginStart: 0 }}
               justifyContent="flex-end"
@@ -233,5 +246,46 @@ export const ModifyProduct = ({ isOpen, onClose, productInfo }: Props) => {
         </ModalBody>
       </ModalContent>
     </Modal>
+  );
+};
+
+const DeleteProductButton = ({
+  modalRef,
+  onDelete,
+}: {
+  modalRef: MutableRefObject<HTMLElement | null>;
+  onDelete: VoidFunction;
+}) => {
+  return (
+    <Popover placement="top-start">
+      <PopoverTrigger>
+        <Button
+          _hover={{
+            textDecoration: 'none',
+            rounded: 'xl',
+            transform: 'scale(1.2)',
+          }}
+          color="#f8f8f8"
+          colorScheme="yellow"
+          rounded="xl"
+        >
+          삭제
+        </Button>
+      </PopoverTrigger>
+      <Portal containerRef={modalRef}>
+        <PopoverContent bg="gray.200" w="100%">
+          <PopoverArrow />
+          <PopoverCloseButton />
+          <PopoverBody>
+            <Heading fontSize="2xl" my="3vh">
+              상품을 삭제할까요?
+            </Heading>
+            <Button colorScheme="yellow" onClick={onDelete}>
+              삭제할게요!
+            </Button>
+          </PopoverBody>
+        </PopoverContent>
+      </Portal>
+    </Popover>
   );
 };

--- a/frontend/src/modals/ModifyProduct.tsx
+++ b/frontend/src/modals/ModifyProduct.tsx
@@ -31,7 +31,7 @@ import { useCallback, useRef, type MutableRefObject } from 'react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { useRecoilValue } from 'recoil';
 import type { Category, ProductWithSalesRecord } from 'src/types/dto';
-import { modProduct } from '../mockApi';
+import { cancelProduct, modProduct } from '../mockApi';
 import { CATEGORIES } from '../modals/consts';
 import { productNameListState } from '../store/product';
 
@@ -59,9 +59,23 @@ export const ModifyProduct = ({ isOpen, onClose, productInfo }: Props) => {
 
   const { mutate: updateMutate } = useMutation({
     mutationFn: modProduct,
-    onSuccess: result => {
+    onSuccess: () => {
       toast({
         title: '상품 수정에 성공했어요 ✏️',
+        status: 'success',
+        position: 'top',
+        duration: 1000,
+        isClosable: true,
+      });
+      onClose();
+    },
+  });
+
+  const { mutate: deleteMutate } = useMutation({
+    mutationFn: cancelProduct,
+    onSuccess: () => {
+      toast({
+        title: '상품 삭제에 성공했어요 ✏️',
         status: 'success',
         position: 'top',
         duration: 1000,
@@ -96,9 +110,7 @@ export const ModifyProduct = ({ isOpen, onClose, productInfo }: Props) => {
     return !some(productNameList, name => name === value);
   }, []);
 
-  const handleDelete = () => {
-    // TODO: 삭제 API 연동
-  };
+  const handleDelete = () => deleteMutate({ id: productInfo.id });
 
   return (
     <Modal isCentered isOpen={isOpen} onClose={onClose}>


### PR DESCRIPTION
## Description
- 상품 삭제 mockAPI 작성
- 상품 정보 모달에 삭제 버튼 추가
- 삭제를 위한 mutate 로직 작성
- 삭제 성공 시 토스트 안내

## What type of PR is this?
- [X] 🍕 Feature

### 작업된 화면
![issue-21](https://github.com/user-attachments/assets/d513bb9b-abf0-483f-8bd3-f6bef3b62152)

## Issue
close #21